### PR TITLE
Handle pre-simulation time and transient

### DIFF
--- a/mesocircuit/core/helpers/base_class.py
+++ b/mesocircuit/core/helpers/base_class.py
@@ -27,15 +27,30 @@ class BaseAnalysisPlotting:
         if self.stim_dict['thalamic_input']:
             self.N_X = np.append(self.N_X, self.stim_dict['num_th_neurons'])
 
-        # temporal bins for raw and resampled spike trains
+        # temporal bins for raw and resampled spike trains,
+        # pre-simulation and actual simulation are combined
         self.time_bins_sim = np.arange(
             0.,
-            self.sim_dict['t_sim'] + self.sim_dict['sim_resolution'],
+            self.sim_dict['t_presim'] + self.sim_dict['t_sim'] + \
+                self.sim_dict['sim_resolution'],
             self.sim_dict['sim_resolution'])
         self.time_bins_rs = np.arange(
             0.,
-            self.sim_dict['t_sim'] + self.ana_dict['binsize_time'],
+            self.sim_dict['t_presim'] + self.sim_dict['t_sim'] + \
+                self.ana_dict['binsize_time'],
             self.ana_dict['binsize_time'])
+
+        # minimum time index for removal of startup transient
+        self.min_time_index_sim = int(self.ana_dict['t_transient'] / \
+                                      self.sim_dict['sim_resolution'])
+        self.min_time_index_rs = int(self.ana_dict['t_transient'] / \
+                                     self.ana_dict['binsize_time'])
+        
+        # time over which statistics are computed (without transient)
+        self.time_statistics = \
+            self.sim_dict['t_presim'] + \
+            self.sim_dict['t_sim'] - \
+            self.ana_dict['t_transient']
 
         # spatial bins
         self.space_bins = np.linspace(-self.net_dict['extent'] / 2.,

--- a/mesocircuit/core/parameterization/base_plotting_params.py
+++ b/mesocircuit/core/parameterization/base_plotting_params.py
@@ -69,7 +69,7 @@ plot_dict = {
 
     ## parameters for plot_raster()
     # time interval for short raster plots (in ms)
-    'raster_time_interval': np.array([0., 1000.]),
+    'raster_time_interval': np.array([500., 1500.]),
     # sample step of raster plot (1 means all neurons are shown).
     # if not a number, but 'auto' is given, a sample step is automatically
     # computed

--- a/mesocircuit/core/plotting/plotting.py
+++ b/mesocircuit/core/plotting/plotting.py
@@ -262,9 +262,10 @@ class Plotting(base_class.BaseAnalysisPlotting):
         cbar_height=0.02):
         """
         """
-        # start time of thalamic pulses is a possible start_time
-        if start_time == 'th_pulse_start':
-            start_time = self.stim_dict[start_time] - self.sim_dict['t_presim']
+        # if the start time is a string, the respective entry from the stimulus
+        # parameters is used
+        if type(start_time) == str:
+            start_time = self.stim_dict[start_time]
 
         start_frame = int(start_time / binsize_time) 
         end_frame = start_frame + (nframes - 1) * step
@@ -549,23 +550,27 @@ class Plotting(base_class.BaseAnalysisPlotting):
 
 
     def plotfunc_CCs_distance(self,
-    ax, X, i, data, max_num_pairs=10000, markersize_scale=0.5):
+        ax, X, i, data, max_num_pairs=10000, markersize_scale=0.4, nblocks=3):
         """
         """
         distances = data[X]['distances_mm'][:max_num_pairs]
         ccs = data[X]['ccs'][:max_num_pairs]
 
         # loop for reducing zorder-bias
-        nblocks = 10
         blocksize = int(len(distances) / nblocks)
         for b in np.arange(nblocks):
             indices = np.arange(b*blocksize, (b+1)*blocksize)
             zorder = 2*b + i%2 # alternating for populations
-            ax.scatter(x=distances[indices],
-                       y=ccs[indices],
-                       s=matplotlib.rcParams['lines.markersize'] * markersize_scale,
-                       c=self.plot_dict['pop_colors'][i],
-                       zorder=zorder)
+
+            ax.plot(distances[indices],
+                    ccs[indices],
+                    marker='$.$',
+                    markersize=matplotlib.rcParams['lines.markersize'] * markersize_scale,
+                    color=self.plot_dict['pop_colors'][i],
+                    markeredgecolor='none',
+                    linestyle='',
+                    zorder=zorder,
+                    rasterized=True)
         return
 
 


### PR DESCRIPTION
- [x] Record raw spikes during pre-simulation time and actual simulation time into different files distinguishable by prefix.
- [x] During preprocessing, merge files from pre-simulation and simulation into .dat files.
  - Node IDs of each population start at 0, but spike times are now always the unmodified times.
- [x] Specify `t_transient` for the analysis which can be, but does not require to be, equal to `t_presim` for the network simulation.
  - Compute statistics from data with `t_transient` removed.

minor:
- [x] Plot distance-dependent correlation coefficients with ax.plot() and rasterized=True.