### PR TITLE
use perl for unlinking raw output data

### DIFF
--- a/mesocircuit/core/simulation/network.py
+++ b/mesocircuit/core/simulation/network.py
@@ -133,7 +133,7 @@ class Network:
                      delete_files=True,
                      filepatterns=['*.dat'],
                      mode='w',
-                     method='perl'):
+                     method='safe'):
         '''
         Create tar file of content in `raw_data/<>` and optionally
         delete files matching given pattern.
@@ -149,8 +149,8 @@ class Network:
         mode: String
             tarfile.open file mode. Default: 'w'
         method: str
-            if method=='perl' (default) use faster perl method (Default),
-            if method=='safe' use safer Path.unlink method.
+            if method=='perl' use faster perl method,
+            if method=='safe' (default) use safer Path.unlink method.
         '''
         output_path = self.sim_dict["path_raw_data"]
 
@@ -169,7 +169,7 @@ class Network:
 
         return
 
-    def __wipe(self, pattern='*', method='perl'):
+    def __wipe(self, pattern='*', method='safe'):
         """ Wipe raw output directory from any existing files.
         Will create folder if it does not exist.
 
@@ -178,8 +178,8 @@ class Network:
         pattern: str
             file pattern to remove. Default '*'
         method: str
-            if method=='perl' (default) use faster perl method (Default),
-            if method=='safe' use safer Path.unlink method.
+            if method=='perl' use faster perl method,
+            if method=='safe' (default) use safer Path.unlink method.
         """
         output_path = self.sim_dict["path_raw_data"]
         if nest.Rank() == 0:
@@ -190,7 +190,7 @@ class Network:
                     os.system('perl -e "for(<' + '{}'.format(pattern) +
                               '>){((stat)[9]<(unlink))}"')
                     os.chdir(cwd)
-                elif method == 'path':
+                elif method == 'safe':
                     for p in Path(output_path).glob(pattern):
                         while p.is_file():
                             try:


### PR DESCRIPTION
This should not be merged! Linked to issue #37 

Did some comparison on jusuf for times required to create tar file/remove raw data with
```
'N_scaling': 1./16,  # 0.008,
'K_scaling': 1.,  # 0.1,
```

NEST: master@24de43dc2

The times required to create a tar file are marginal compared to overall simulation times. Using perl to unlink files is slightly slower than `Path.unlink`. What is worse is a fourfold increase in simulation times by going to 4 nodes vs. 1 node. 

1 nodes/64 processes/256 threads:
@master
```
+---------+--------+---------+-------------+----------+--------------+
| Time measurements in s: run_network.py                             |
+---------+--------+---------+-------------+----------+--------------+
|         | create | connect | presimulate | simulate | tar_raw_data |
+---------+--------+---------+-------------+----------+--------------+
| RANK 0  |  1.509 | 153.306 |      67.483 |  133.531 |        8.021 |
...
| RANK 63 |  1.386 |   153.3 |      67.527 |  133.554 |        7.984 |
+---------+--------+---------+-------------+----------+--------------+
```

@fix-37
```
+---------+--------+---------+-------------+----------+--------------+
| Time measurements in s: run_network.py                             |
+---------+--------+---------+-------------+----------+--------------+
|         | create | connect | presimulate | simulate | tar_raw_data |
+---------+--------+---------+-------------+----------+--------------+
| RANK 0  |  2.032 | 152.407 |       67.52 |  133.436 |        9.009 |
...
| RANK 63 |  1.964 | 152.444 |      67.518 |  133.441 |        8.983 |
+---------+--------+---------+-------------+----------+--------------+
```

4 nodes/256 processes/1024 threads:
@master
```
+----------+--------+---------+-------------+----------+--------------+
| Time measurements in s: run_network.py                              |
+----------+--------+---------+-------------+----------+--------------+
|          | create | connect | presimulate | simulate | tar_raw_data |
+----------+--------+---------+-------------+----------+--------------+
| RANK 0   |  3.165 | 145.341 |     258.624 |  525.517 |       47.095 |
...
| RANK 255 |  3.364 |  146.69 |     258.621 |  525.505 |       47.091 |
+----------+--------+---------+-------------+----------+--------------+
```
@fix-37
```
+----------+--------+---------+-------------+----------+--------------+
| Time measurements in s: run_network.py                              |
+----------+--------+---------+-------------+----------+--------------+
|          | create | connect | presimulate | simulate | tar_raw_data |
+----------+--------+---------+-------------+----------+--------------+
| RANK 0   |  3.402 |  144.98 |     258.702 |  525.269 |       53.102 |
...
| RANK 255 |  3.531 | 144.676 |     258.709 |  525.299 |       53.128 |
+----------+--------+---------+-------------+----------+--------------+
```