### PR TITLE
Effective mean and std of linear delay

### DIFF
--- a/mesocircuit/core/helpers/mesocircuit_framework.py
+++ b/mesocircuit/core/helpers/mesocircuit_framework.py
@@ -153,7 +153,9 @@ def evaluate_parameterset(ps_id, paramset):
             f.write(json_dump)
     # parameters for LIF Meanfield Tools
     lmt_dic = params_for_lif_meanfield_tools(paramset['net_dict'])
-    filename = os.path.join(paramset['sim_dict']['path_parameters'], 'lmt_dict')
+    filename = os.path.join(
+        paramset['sim_dict']['path_parameters'],
+        'lmt_dict')
     with open(filename + '.yaml', 'w') as f:
         yaml.dump(lmt_dic, f, default_flow_style=False)
 
@@ -182,19 +184,19 @@ def params_for_lif_meanfield_tools(net_dict):
     if net_dict['delay_type'] == 'normal':
         d_e_mean = net_dict['delay_exc_mean']
         d_i_mean = net_dict['delay_inh_mean']
-        d_e_sd = d_e_mean *  net_dict['delay_rel_std']
-        d_i_sd = d_i_mean *  net_dict['delay_rel_std']
+        d_e_sd = d_e_mean * net_dict['delay_rel_std']
+        d_i_sd = d_i_mean * net_dict['delay_rel_std']
 
     elif net_dict['delay_type'] == 'linear':
         # get columns from exc. or inh. sources and average
-        d_e_mean = float(np.mean(net_dict['delay_lin_eff_mean'][:,::2]))
-        d_i_mean = float(np.mean(net_dict['delay_lin_eff_mean'][:,1::2]))
-        d_e_sd = float(np.mean(net_dict['delay_lin_eff_std'][:,::2]))
-        d_i_sd = float(np.mean(net_dict['delay_lin_eff_std'][:,1::2]))
+        d_e_mean = float(np.mean(net_dict['delay_lin_eff_mean'][:, ::2]))
+        d_i_mean = float(np.mean(net_dict['delay_lin_eff_mean'][:, 1::2]))
+        d_e_sd = float(np.mean(net_dict['delay_lin_eff_std'][:, ::2]))
+        d_i_sd = float(np.mean(net_dict['delay_lin_eff_std'][:, 1::2]))
 
     dic = {
-        'label': 'microcircuit', # for correct parameter derivations
-        'populations': net_dict['populations'][:-1].tolist(), # no thalamus
+        'label': 'microcircuit',  # for correct parameter derivations
+        'populations': net_dict['populations'][:-1].tolist(),  # no thalamus
         'N': net_dict['full_num_neurons'][:-1].tolist(),
         'C': {'val': net_dict['neuron_params']['C_m'],
               'unit': 'pF'},
@@ -213,14 +215,14 @@ def params_for_lif_meanfield_tools(net_dict):
         'd_i': {'val': d_i_mean,
                 'unit': 'ms'},
         'd_e_sd': {'val': d_e_sd,
-                   'unit': 'ms'}, 
+                   'unit': 'ms'},
         'd_i_sd': {'val': d_i_sd,
                    'unit': 'ms'},
         'delay_dist': 'none',
         # use L23E -> L23E
         'w': {'val': net_dict['full_weight_matrix_mean'][0][0].tolist(),
               'unit': 'pA'},
-        'K': net_dict['full_indegrees'][:,:-1].tolist(),
+        'K': net_dict['full_indegrees'][:, :-1].tolist(),
         'g': - net_dict['g'],
         'nu_ext': {'val': net_dict['bg_rate'],
                    'unit': 'Hz'},

--- a/mesocircuit/core/parameterization/helpers_network.py
+++ b/mesocircuit/core/parameterization/helpers_network.py
@@ -403,7 +403,11 @@ def get_exc_inh_matrix(val_exc, val_inh, num_pops):
     return matrix
 
 
-def get_delay_lin_effective(extent, beta, delay_offset_matrix, prop_speed_matrix):
+def get_delay_lin_effective(
+        extent,
+        beta,
+        delay_offset_matrix,
+        prop_speed_matrix):
     """
     Computes the effective mean and standard deviation of the linear delay.
 
@@ -419,7 +423,7 @@ def get_delay_lin_effective(extent, beta, delay_offset_matrix, prop_speed_matrix
         Matrix of delay offsets (in ms).
     prop_speed_matrix
         Matrix of propagation speeds (in mm/ms).
-    
+
     Returns
     -------
     delay_lin_eff_mean_matrix
@@ -437,7 +441,7 @@ def get_delay_lin_effective(extent, beta, delay_offset_matrix, prop_speed_matrix
         return np.exp(-r / b)
 
     def integrand(r, R, b, variable):
-        atan = 4. * scipy.arctan(np.sqrt((2.*R - r) / (2.*R + r)))
+        atan = 4. * scipy.arctan(np.sqrt((2. * R - r) / (2. * R + r)))
         return variable * connfunc(r, b) * r * (atan - np.sin(atan))
 
     def integrand_delay_mean(r, R, b, d0, v):
@@ -449,17 +453,17 @@ def get_delay_lin_effective(extent, beta, delay_offset_matrix, prop_speed_matrix
     def integrand_conn_norm(r, R, b):
         return integrand(r, R, b, 1)
 
-    R = extent / 2. # radius of circle
-    limits = [0., R] # integral bounds
+    R = extent / 2.  # radius of circle
+    limits = [0., R]  # integral bounds
     num_pops = len(delay_offset_matrix)
 
     delay_lin_eff_mean_matrix = np.zeros((num_pops, num_pops))
     delay_lin_eff_std_matrix = np.zeros((num_pops, num_pops))
     for i in np.arange(num_pops):
         for j in np.arange(num_pops):
-            d0 = delay_offset_matrix[i,j]
-            v = prop_speed_matrix[i,j]
-            b = beta[i,j]
+            d0 = delay_offset_matrix[i, j]
+            v = prop_speed_matrix[i, j]
+            b = beta[i, j]
 
             I_delay_mean = scipy.integrate.quad(integrand_delay_mean,
                                                 limits[0],
@@ -482,8 +486,8 @@ def get_delay_lin_effective(extent, beta, delay_offset_matrix, prop_speed_matrix
             dvar = I_delay_var / I_conn_norm
             dstd = np.sqrt(dvar)
 
-            delay_lin_eff_mean_matrix[i,j] = dmean
-            delay_lin_eff_std_matrix[i,j] = dstd
+            delay_lin_eff_mean_matrix[i, j] = dmean
+            delay_lin_eff_std_matrix[i, j] = dstd
     return delay_lin_eff_mean_matrix, delay_lin_eff_std_matrix
 
 


### PR DESCRIPTION
Computes mean and std of linear delay accounting for the exponential connectivity profile.
For the LIF Meanfield Tools parameter file, the average values for excitatory and inhibitory connections are assumed. 

Solves #38. 