### PR TITLE
Scale spatial mask with respect to beta

### DIFF
--- a/mesocircuit/core/parameterization/base_network_params.py
+++ b/mesocircuit/core/parameterization/base_network_params.py
@@ -238,6 +238,9 @@ net_dict = {
     # The final beta is beta_unscaled * beta_scaling.
     'beta_scaling': 1.,
 
+    # scaling factor for mask to be multiplied with the respective beta
+    'mask_scaling': 4.,
+
     # TODO maybe remove
     # If beta_exh_inh is not False, it must be a list with excitatory and
     # inhibitory decay parameters [beta_exc, beta_inh] which will be used to

--- a/mesocircuit/core/simulation/network.py
+++ b/mesocircuit/core/simulation/network.py
@@ -539,7 +539,8 @@ class Network:
                                 x=nest.spatial.distance,
                                 beta=self.net_dict['beta'][i][j]),
                             'mask': {'circular': {
-                                'radius': self.net_dict['extent'] / 2.}}}
+                                'radius': (self.net_dict['beta'][i][j]*
+                                           self.net_dict['mask_scaling'])}}}
                     elif self.net_dict['connect_method'] == 'distr_indegree_exp':
                         conn_dict_rec = {
                             'rule': 'pairwise_bernoulli',
@@ -548,7 +549,8 @@ class Network:
                                     x=nest.spatial.distance,
                                     beta=self.net_dict['beta'][i][j]),
                             'mask': {'circular': {
-                                'radius': self.net_dict['extent'] / 2.}}}
+                                'radius': (self.net_dict['beta'][i][j]*
+                                           self.net_dict['mask_scaling'])}}}
                     # TODO only temporary
                     elif self.net_dict['connect_method'] == 'distr_indegree_gauss':
                         conn_dict_rec = {
@@ -559,7 +561,9 @@ class Network:
                                     mean=0,
                                     std=self.net_dict['beta'][i][j]),
                             'mask': {'circular': {
-                                'radius': self.net_dict['extent'] / 2.}}}
+                                'radius': (self.net_dict['beta'][i][j]*
+                                           self.net_dict['mask_scaling'])}}}
+
                     else:
                         raise Exception('connect_method is incorrect.')
 


### PR DESCRIPTION
If a spatial profile with decay constant `beta` is used, only neurons within a spatial mask are connected. Before the mask radius was fixed to `extent/2`. Now it is `beta*mask_scaling`. With a `mask_scaling` of 4 (used as default), an exponential profile has already decayed to <2%, therefore the distortion of the profile is negligible. This speeds up the connection routine.
Idea from @jasperalbers and @ackurth.