### PR TITLE
Use kwarg `dtype` in `SpikeAnalysis._time_and_space_binned_sptrains_X()`

### DIFF
--- a/mesocircuit/core/analysis/spike_analysis.py
+++ b/mesocircuit/core/analysis/spike_analysis.py
@@ -405,12 +405,12 @@ class SpikeAnalysis(base_class.BaseAnalysisPlotting):
             # simulation resolution
             elif datatype == 'sptrains':
                 datasets[datatype] = self.__time_binned_sptrains_X(
-                    i, spikes, self.time_bins_sim, dtype=np.uint8)
+                    self.N_X[i], spikes, self.time_bins_sim, dtype=np.uint8)
 
             # time-binned spike trains
             elif datatype == 'sptrains_bintime':
                 datasets[datatype] = self.__time_binned_sptrains_X(
-                    i, spikes, self.time_bins_rs, dtype=np.uint8)
+                    self.N_X[i], spikes, self.time_bins_rs, dtype=np.uint8)
 
             # time-binned and space-binned spike trains
             elif datatype == 'sptrains_bintime_binspace':
@@ -486,7 +486,7 @@ class SpikeAnalysis(base_class.BaseAnalysisPlotting):
                    'y-position_mm': positions['y-position_mm']}
         return pos_dic
 
-    def __time_binned_sptrains_X(self, i, spikes, time_bins, dtype):
+    def __time_binned_sptrains_X(self, N_X, spikes, time_bins, dtype):
         """
         Computes a spike train as a histogram with ones for each spike at a
         given time binning.
@@ -499,8 +499,8 @@ class SpikeAnalysis(base_class.BaseAnalysisPlotting):
 
         Parameters
         ----------
-        i
-            Population index.
+        N_X
+            Size of population X.
         spikes: ndarray
             Array of node ids and spike times.
         time_bins: ndarray
@@ -515,7 +515,7 @@ class SpikeAnalysis(base_class.BaseAnalysisPlotting):
 
         """
         # if no spikes were recorded, return an empty sparse matrix
-        shape = (self.N_X[i], time_bins.size)
+        shape = (N_X, time_bins.size)
 
         if spikes.size == 0:
             sptrains_bintime = sp.coo_matrix(shape, dtype=dtype)

--- a/mesocircuit/tests/test_suite.py
+++ b/mesocircuit/tests/test_suite.py
@@ -44,7 +44,7 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
@@ -72,7 +72,7 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
@@ -106,7 +106,7 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
@@ -140,7 +140,7 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
@@ -179,12 +179,12 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
         sptrains_bin_space_time = sana._time_and_space_binned_sptrains_X(
-            X, positions, sptrains_bin_time,
+            positions, sptrains_bin_time,
             dtype=np.uint16)
 
         gt = np.eye((sana.space_bins.size - 1)**2)
@@ -219,12 +219,12 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
         sptrains_bin_space_time = sana._time_and_space_binned_sptrains_X(
-            X, positions, sptrains_bin_time,
+            positions, sptrains_bin_time,
             dtype=np.uint16)
 
         gt = np.eye((sana.space_bins.size - 1)**2)
@@ -260,12 +260,12 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
         sptrains_bin_space_time = sana._time_and_space_binned_sptrains_X(
-            X, positions, sptrains_bin_time,
+            positions, sptrains_bin_time,
             dtype=np.uint16)
 
         gt = np.eye((sana.space_bins.size - 1)**2)
@@ -300,13 +300,13 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
         try:
             sptrains_bin_space_time = sana._time_and_space_binned_sptrains_X(
-                X, positions, sptrains_bin_time,
+                positions, sptrains_bin_time,
                 dtype=np.uint16)
         except NotImplementedError:
             pass
@@ -340,13 +340,13 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
         try:
             sptrains_bin_space_time = sana._time_and_space_binned_sptrains_X(
-                X, positions, sptrains_bin_time,
+                positions, sptrains_bin_time,
                 dtype=np.uint16)
         except NotImplementedError:
             pass
@@ -382,12 +382,12 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
         sptrains_bin_space_time = sana._time_and_space_binned_sptrains_X(
-            X, positions, sptrains_bin_time,
+            positions, sptrains_bin_time,
             dtype=np.uint16)
 
         gt = np.c_[np.eye((sana.space_bins.size - 1)**2),
@@ -423,12 +423,12 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
         sptrains_bin_space_time = sana._time_and_space_binned_sptrains_X(
-            X, positions, sptrains_bin_time,
+            positions, sptrains_bin_time,
             dtype=np.uint16)
 
         gt = np.zeros(((sana.space_bins.size - 1)**2, time_bins.size))
@@ -466,12 +466,12 @@ class TestSuite(unittest.TestCase):
         sana = SpikeAnalysis(sim_dict, net_dict, ana_dict)
 
         sptrains_bin_time = sana._SpikeAnalysis__time_binned_sptrains_X(
-            X=X,
+            N_X=N_X,
             spikes=spikes,
             time_bins=time_bins, dtype=int)
 
         sptrains_bin_space_time = sana._time_and_space_binned_sptrains_X(
-            X, positions, sptrains_bin_time,
+            positions, sptrains_bin_time,
             dtype=np.uint16)
 
         gt = np.zeros(((sana.space_bins.size - 1)**2, time_bins.size))


### PR DESCRIPTION
Fixes #107 

In addition, this PR removes the unused argument `X` from some analysis functions.