### PR TITLE
If HOSTNAME is not found, use SYSTEMNAME on JURECA

### DIFF
--- a/mesocircuit/parameterization/base_system_params.py
+++ b/mesocircuit/parameterization/base_system_params.py
@@ -12,6 +12,9 @@ if 'HOSTNAME' in os.environ:
     partition = ('dc-cpu'
                  if os.environ['HOSTNAME'].rfind('jureca') > 0
                  else 'batch')
+elif 'SYSTEMNAME' in os.environ:
+    if os.environ['SYSTEMNAME'] == 'jurecadc':
+        partition = 'dc-cpu'
 else:
     partition = None
 


### PR DESCRIPTION
Readds functionality from commit a2e85b1666f1ccf0543ab17835c2d85f65a6402d.

```
[ __ ]$ python
Python 3.9.6 (default, Nov 16 2021, 12:23:51) 
[GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.environ['HOSTNAME']
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/p/software/jurecadc/stages/2022/software/Python/3.9.6-GCCcore-11.2.0/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'HOSTNAME'
>>> os.environ['SYSTEMNAME']
'jurecadc'
```
Previously, `HOSTNAME` was set in Python's `os.environ` from `hostname` on JURECA, but it seems that this is not always the case. Therefore we have now a fallback to `SYSTEMNAME`.