### PR TITLE
Option to scramble neuron ids for raster

### DIFF
--- a/mesocircuit/plotting/ms_figures.py
+++ b/mesocircuit/plotting/ms_figures.py
@@ -122,9 +122,10 @@ def reference_vs_upscaled(output_dir, ref_circuit, ups_circuit):
             all_sptrains=d[prefix + '_all_sptrains'],
             all_pos_sorting_arrays=d[prefix + '_all_pos_sorting_arrays'],
             time_step=plot.sim_dict['sim_resolution'],
-            # plot.plot_dict['raster_time_interval_short'],
             time_interval=[1000, 1050],
-            sample_step=1)
+            sample_step=1,
+            randomize_neuronids=True,
+        )
         plot.add_label(ax, labels[i])
         ax.set_title(titles[i])
 

--- a/mesocircuit/plotting/plotting.py
+++ b/mesocircuit/plotting/plotting.py
@@ -124,12 +124,14 @@ class Plotting(base_class.BaseAnalysisPlotting):
                     yticks=True,
                     yticklabels=True,
                     markersize_scale=0.25,
-                    axvline=None):
+                    axvline=None,
+                    randomize_neuronids=False,
+                    random_seed=567):
         """
         Plots spike raster to gridspec cell.
 
         Neurons are sorted according to sorting_axis applied in
-        all_pos_sorting_arrays.
+        all_pos_sorting_arrays if randomize_neuronids=False.
 
         Parameters
         ----------
@@ -158,6 +160,11 @@ class Plotting(base_class.BaseAnalysisPlotting):
             Scaling factor for marker size.
         axvhline
             Time point of vertical line in ms.
+        randomize_neuronids
+            Whether to scramble neuron ids.
+        random_seed
+            Random seed used to scramble neuron ids.
+
         Returns
         -------
         ax
@@ -175,9 +182,16 @@ class Plotting(base_class.BaseAnalysisPlotting):
                 time_interval[1] / time_step).astype(int)
             data = data[:, time_indices]
 
+            # deterministically randomize neuron ids
+            if randomize_neuronids:
+                np.random.seed(random_seed)
+                rnd_indices = np.arange(np.shape(data)[0])
+                np.random.shuffle(rnd_indices)
+                data = data[rnd_indices, :]
             # sort according to spatial axis
-            space_indices = all_pos_sorting_arrays[X][()]
-            data = data[space_indices, :]
+            else:
+                space_indices = all_pos_sorting_arrays[X][()]
+                data = data[space_indices, :]
 
             # subsample if specified
             if sample_step > 1:


### PR DESCRIPTION
Deterministic by setting the random seed directly before shuffling.
This is now used in the comparison raster of reference vs. upscaled_1mm2.