### PR TITLE
dont overload srun args, fix mpi error

### DIFF
--- a/mesocircuit/mesocircuit_framework.py
+++ b/mesocircuit/mesocircuit_framework.py
@@ -551,7 +551,10 @@ unset DISPLAY
                             print(
                                 "LD_PRELOAD skipped because jemalloc is not in PATH.")
 
-                    run_cmd = f'srun --cpus-per-task={dic["local_num_threads"]} --threads-per-core=1 --cpu-bind=rank'
+                    if name in ['lfp_simulation', 'lfp_postprocess', 'lfp_plotting']:
+                        run_cmd = f'srun --mpi=pmi2'
+                    else:
+                        run_cmd = f'srun --cpus-per-task={dic["local_num_threads"]} --threads-per-core=1 --cpu-bind=rank'
 
                 elif machine == 'local':
                     # check which executables are available


### PR DESCRIPTION
Turns out, LFP simulations require `srun --mpi=pmi2` argument, removed in https://github.com/INM-6/mesocircuit-model/commit/e67706970fb3c280c64e1ddfa40b24a6a8db964b