### PR TITLE
Create output dir if it doesn't exist.

### DIFF
--- a/mesocircuit/mesocircuit_framework.py
+++ b/mesocircuit/mesocircuit_framework.py
@@ -66,8 +66,8 @@ class MesocircuitExperiment():
 
         # check if data directory exists
         if not os.path.isdir(self.data_dir_exp):
-            raise Exception(
-                f'Data directory does not exist: {self.data_dir_exp}')
+            print(f'creating directory {self.data_dir_exp}')
+            os.makedirs(self.data_dir_exp)
         
         print(f'Data directory: {self.data_dir_exp}')
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='mesocircuit',
-      version='0.1.0',
+      version='0.1.1dev0',
       description='Mesocircuit Model',
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION

Fixes #215

Instead of raising an exception if the data directory doesn't exist, create it instead. 