### PR TITLE
Allow for scalar or iterable list of time windows for calculating correlation coefficients

### DIFF
--- a/mesocircuit/analysis/spike_analysis.py
+++ b/mesocircuit/analysis/spike_analysis.py
@@ -826,10 +826,22 @@ def _compute_statistics_X(i, X, circuit):
 
             # correlation coefficients with distances
             elif datatype == 'CCs_distances':
-                dataset = _compute_ccs_distances(
-                    X, circuit,
-                    d['sptrains_X'], circuit.sim_dict['sim_resolution'],
-                    d['positions_X'])
+                try:
+                    dataset = {}
+                    for i, ccs_time_interval in enumerate(iter(circuit.ana_dict['ccs_time_interval'])):
+                        dataset.update(_compute_ccs_distances(
+                            X, circuit,
+                            d['sptrains_X'],
+                            circuit.sim_dict['sim_resolution'],
+                            ccs_time_interval,
+                            d['positions_X']))
+                except TypeError as _:
+                    dataset = _compute_ccs_distances(
+                        X, circuit,
+                        d['sptrains_X'],
+                        circuit.sim_dict['sim_resolution'],
+                        circuit.ana_dict['ccs_time_interval'],
+                        d['positions_X'])
 
             # power spectral densities
             elif datatype == 'PSDs':
@@ -923,7 +935,7 @@ def _compute_lvs(sptrains_X):
     return lvs
 
 
-def _compute_ccs_distances(X, circuit, sptrains_X, binsize_time, positions_X):
+def _compute_ccs_distances(X, circuit, sptrains_X, binsize_time, ccs_time_interval, positions_X):
     """
     Computes Pearson correlation coefficients (excluding auto-correlations)
     and distances between correlated neurons.
@@ -938,6 +950,8 @@ def _compute_ccs_distances(X, circuit, sptrains_X, binsize_time, positions_X):
         Sptrains of population X in sparse csr format.
     binsize_time
         Temporal resolution of sptrains_X (in ms).
+    ccs_time_interval
+        Temporal bin size(s) for correlation coefficients calculation (in ms).
     positions_X
         Positions of population X.
     """
@@ -953,7 +967,7 @@ def _compute_ccs_distances(X, circuit, sptrains_X, binsize_time, positions_X):
     # number of time steps in data
     num_timesteps = sptrains_X.shape[1] - 1  # last time bin discarded
     # number of time bins to be combined
-    ntbin = int(circuit.ana_dict['ccs_time_interval'] / binsize_time)
+    ntbin = int(ccs_time_interval / binsize_time)
     # container for binned spike trains of the selected number
     spt = np.empty((num_neurons, int(num_timesteps/ntbin)), dtype=int)
     mask_nrns = np.zeros(num_neurons_data, dtype=bool)
@@ -1004,7 +1018,7 @@ def _compute_ccs_distances(X, circuit, sptrains_X, binsize_time, positions_X):
                            extent=[circuit.net_dict['extent']] * 2,
                            edge_wrap=True)
 
-    ccs_dic = {'ccs': ccs,
+    ccs_dic = {f'ccs_{ccs_time_interval}ms': ccs,
                'distances_mm': distances}
     return ccs_dic
 

--- a/mesocircuit/mesocircuit_framework.py
+++ b/mesocircuit/mesocircuit_framework.py
@@ -66,7 +66,7 @@ class MesocircuitExperiment():
 
         # check if data directory exists
         if not os.path.isdir(self.data_dir_exp):
-            print(f'creating directory {self.data_dir_exp}')
+            print(f'Creating directory: {self.data_dir_exp}')
             os.makedirs(self.data_dir_exp)
         
         print(f'Data directory: {self.data_dir_exp}')

--- a/mesocircuit/parameterization/base_analysis_params.py
+++ b/mesocircuit/parameterization/base_analysis_params.py
@@ -63,8 +63,9 @@ ana_dict = {
     # latter is also assumed.
     'ccs_num_neurons': 200,
     # time interval for computing correlation coefficients (in ms).
-    # a good choice is equal to the refractory time
-    'ccs_time_interval': 2.0,
+    # a good choice is equal to the refractory time.
+    # it can also be an iterable list of time intervals, e.g., [2., 50., 200.]
+    'ccs_time_interval': 2.,
 
     # number of data points used in each block for the FFT
     'psd_NFFT': 512,

--- a/mesocircuit/plotting/figures.py
+++ b/mesocircuit/plotting/figures.py
@@ -330,21 +330,35 @@ def corrcoef_distance(circuit, all_CCs_distances):
     """
     print('Plotting correlation coefficients vs. distance.')
 
-    fig = plt.figure(figsize=(circuit.plot_dict['fig_width_1col'], 5.))
-    gs = gridspec.GridSpec(1, 1)
-    gs.update(top=0.98, bottom=0.09, left=0.17, right=0.98)
-    ax = plot.plot_layer_panels(
-        gs[0, 0],
-        plotfunc=plot.plotfunc_CCs_distance,
-        populations=circuit.ana_dict['Y'],
-        layer_labels=circuit.plot_dict['layer_labels'],
-        pop_colors=circuit.plot_dict['pop_colors'],
-        data=all_CCs_distances,
-        xlabel='distance (mm)',
-        ylabel=r'$CC$')
+    def _corrcoef_distance(key_ccs):
+        fig = plt.figure(figsize=(circuit.plot_dict['fig_width_1col'], 5.))
+        gs = gridspec.GridSpec(1, 1)
+        gs.update(top=0.98, bottom=0.09, left=0.17, right=0.98)
+        ax = plot.plot_layer_panels(
+            gs[0, 0],
+            plotfunc=plot.plotfunc_CCs_distance,
+            populations=circuit.ana_dict['Y'],
+            layer_labels=circuit.plot_dict['layer_labels'],
+            pop_colors=circuit.plot_dict['pop_colors'],
+            data=all_CCs_distances,
+            key_ccs=key_ccs,
+            xlabel='distance (mm)',
+            ylabel=r'$CC$')
+        return fig
 
-    plot.savefig(circuit.data_dir_circuit, circuit.plot_dict['extension'],
-                 'corrcoef_distance')
+    try:
+        # one figure per time interval if a list is provided
+        for i, ccs_time_interval in enumerate(iter(circuit.ana_dict['ccs_time_interval'])):
+            key_ccs = f'ccs_{ccs_time_interval}'
+            fig = _corrcoef_distance(key_ccs)
+            plot.savefig(circuit.data_dir_circuit, circuit.plot_dict['extension'],
+                         f'corrcoef_distance_{key_ccs}ms')
+    except TypeError as _:
+        ccs_time_interval = circuit.ana_dict['ccs_time_interval']
+        key_ccs = f'ccs_{ccs_time_interval}'
+        fig = _corrcoef_distance(key_ccs)
+        plot.savefig(circuit.data_dir_circuit, circuit.plot_dict['extension'],
+                     f'corrcoef_distance_{key_ccs}ms')
     return
 
 

--- a/mesocircuit/plotting/figures.py
+++ b/mesocircuit/plotting/figures.py
@@ -300,7 +300,15 @@ def statistics_overview(circuit, all_FRs, all_LVs, all_CCs_distances, all_PSDs):
     all_CCs = {}
     for X in all_CCs_distances:
         if isinstance(all_CCs_distances[X], h5py._hl.group.Group):
-            all_CCs[X] = all_CCs_distances[X]['ccs']
+            try:
+                iter(circuit.ana_dict['ccs_time_interval'])
+                ccs_time_interval = circuit.ana_dict['ccs_time_interval'][0]
+                all_CCs[X] = all_CCs_distances[X][f'ccs_{ccs_time_interval}ms']
+
+                print('CCs in statistics_overview use only first value in list of time intervals: ' +
+                      f'{ccs_time_interval}')
+            except TypeError:
+                all_CCs[X] = all_CCs_distances[X][f'ccs_{circuit.ana_dict["ccs_time_interval"]}ms']
         else:
             all_CCs[X] = np.array([])
 

--- a/mesocircuit/plotting/plotting.py
+++ b/mesocircuit/plotting/plotting.py
@@ -875,7 +875,8 @@ def plot_layer_panels(
                 else:
                     y0 = 0
 
-                ax.set_ylim(y0, np.max([ymax, ymax1]) * 1.1)
+                ax.set_ylim(np.min([ymin, ymin1, y0]),
+                            np.max([ymax, ymax1]) * 1.1)
 
         if layer_count == len(layer_labels) - 1:
             ax.set_xlabel(xlabel)
@@ -1204,6 +1205,7 @@ def plotfunc_CCs_distance(
         X,
         i,
         data,
+        key_ccs,
         pop_colors,
         max_num_pairs=10000,
         markersize_scale=0.4,
@@ -1216,7 +1218,7 @@ def plotfunc_CCs_distance(
         return
 
     distances = data[X]['distances_mm'][:max_num_pairs]
-    ccs = data[X]['ccs'][:max_num_pairs]
+    ccs = data[X][key_ccs][:max_num_pairs]
 
     # loop for reducing zorder-bias
     blocksize = int(len(distances) / nblocks)
@@ -1350,6 +1352,10 @@ def savefig(
 
     Parameters
     ----------
+    data_dir_circuit
+        Path to data directory
+    extension
+        File extension.
     filename
         Name of the file.
     eps_conv


### PR DESCRIPTION
Fixes #216 

One plot per time window.

statistics_overview shows the distributions of correlation coefficients for the first in the list, if a list is provided.

Implementation based on branch https://github.com/INM-6/mesocircuit-model/tree/espenhgn/issue216 by @espenhgn .