### PR TITLE
Avoid use of GetLocalNodeCollection

### DIFF
--- a/mesocircuit/simulation/network.py
+++ b/mesocircuit/simulation/network.py
@@ -315,12 +315,18 @@ class Network:
         for i, (label, pop) in enumerate(zip(self.net_dict['populations'],
 
                                              self.pops)):
-            # extract layer nodes and positions on this RANK
-            nodes = nest.GetLocalNodeCollection(pop)
-            if len(nodes) > 1:
-                pos = np.array(nest.GetPosition(nodes))
-            elif len(nodes) == 1:
-                pos = np.array(nest.GetPosition(nodes)).reshape((1, 2))
+            # As a work-around to NEST #3706, we extract node IDs and position information separately.
+            # The spatial position as those of the local nodes only and have the same ordering as
+            # the global ids.
+            node_ids = pop[pop.local].global_id
+            node_pos = pop.spatial["positions"]
+            n_local = len(node_ids)
+            assert len(node_pos) == n_local, f"Node IDs and positions arrays have different lengths ({n_local} vs {len(node_pos)})"
+            
+            if n_local > 1:
+                pos = np.array(node_pos)
+            elif n_local == 1:
+                pos = np.array(node_pos).reshape((1, 2))
             else:
                 pos = np.zeros((0, 2))
 
@@ -330,8 +336,8 @@ class Network:
             formats = ['i4', 'f8', 'f8']
 
             # construct record array
-            data = np.recarray((len(nodes), ), names=names, formats=formats)
-            data['nodeid'] = nodes
+            data = np.recarray((n_local, ), names=names, formats=formats)
+            data['nodeid'] = node_ids
             data['x-position_mm'] = pos[:, 0]
             data['y-position_mm'] = pos[:, 1]
 

--- a/mesocircuit/simulation/network.py
+++ b/mesocircuit/simulation/network.py
@@ -529,11 +529,11 @@ class Network:
 
                     # specify synapse parameters
                     if self.net_dict['weight_matrix_mean'][i][j] < 0:
-                        w_min = np.NINF
+                        w_min = -np.inf
                         w_max = 0.0
                     else:
                         w_min = 0.0
-                        w_max = np.Inf
+                        w_max = np.inf
 
                     if self.net_dict['delay_type'] == 'normal':
                         delay_param = nest.random.normal(
@@ -562,7 +562,7 @@ class Network:
                             # https://nest-simulator.readthedocs.io/en/latest/nest_behavior
                             # /random_numbers.html#rounding-effects-when-randomizing-delays
                             min=nest.resolution - 0.5 * nest.resolution,
-                            max=np.Inf)}
+                            max=np.inf)}
 
                     # repeat_connect is 1 apart from rule pairwise_bernoulli
                     # ('connect_method' == 'distr_indegree_exp').


### PR DESCRIPTION
In current NEST master, `GetLocalNodeCollection` is broken and my be deprecated. This PR avoids its use for extracting and storing node positions.